### PR TITLE
Add postcss plugin to remove `:is` wrappers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "vue": "^3.2.41"
       },
       "devDependencies": {
+        "@csstools/postcss-is-pseudo-class": "^3.2.0",
         "@rushstack/eslint-patch": "^1.1.4",
         "@types/node": "^16.11.68",
         "@vitejs/plugin-vue": "^3.1.2",
@@ -38,6 +39,42 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@csstools/postcss-is-pseudo-class": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-3.2.0.tgz",
+      "integrity": "sha512-uooelBL99jMg8ZD6xy0Pj1hSalchWmplcin00eI+JHpv1jW2iwbi1cn2UnVsToM4JLwJSZFzTSWCgSpmlyhe3A==",
+      "dev": true,
+      "dependencies": {
+        "@csstools/selector-specificity": "^2.0.0",
+        "postcss-selector-parser": "^6.0.10"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/csstools"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/selector-specificity": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
+      "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
+      "dev": true,
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/csstools"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^6.0.10"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -4438,6 +4475,23 @@
       "version": "7.21.4",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.4.tgz",
       "integrity": "sha512-alVJj7k7zIxqBZ7BTRhz0IqJFxW1VJbm6N8JbcYhQ186df9ZBPbZBmWSqAMXwHGsCJdYks7z/voa3ibiS5bCIw=="
+    },
+    "@csstools/postcss-is-pseudo-class": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-3.2.0.tgz",
+      "integrity": "sha512-uooelBL99jMg8ZD6xy0Pj1hSalchWmplcin00eI+JHpv1jW2iwbi1cn2UnVsToM4JLwJSZFzTSWCgSpmlyhe3A==",
+      "dev": true,
+      "requires": {
+        "@csstools/selector-specificity": "^2.0.0",
+        "postcss-selector-parser": "^6.0.10"
+      }
+    },
+    "@csstools/selector-specificity": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
+      "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
+      "dev": true,
+      "requires": {}
     },
     "@esbuild/android-arm": {
       "version": "0.15.18",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "vue": "^3.2.41"
   },
   "devDependencies": {
+    "@csstools/postcss-is-pseudo-class": "^3.2.0",
     "@rushstack/eslint-patch": "^1.1.4",
     "@types/node": "^16.11.68",
     "@vitejs/plugin-vue": "^3.1.2",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -3,5 +3,6 @@ module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},
+    "@csstools/postcss-is-pseudo-class": {},
   },
 };


### PR DESCRIPTION
Hi! Jordan from Tailwind Labs here. I'm opening this PR to showcase a workaround for the `:is` selector issue that's caused by using `@apply` inside scoped style selectors that also use `:deep`.

I'll be responding to your issue in the Tailwind CSS repo shortly! ✨ 